### PR TITLE
added conditional platform requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -98,7 +98,8 @@ pyflakes==2.5.0
 Pygments==2.12.0
 PyNaCl==1.5.0
 pyparsing==3.0.9
-pypiwin32==223
+pypiwin32==223; platform_system == 'Windows'
+pywin32==304; platform_system == 'Windows'
 pyrsistent==0.18.1
 pysftp==0.2.9
 python-box==6.0.2
@@ -109,7 +110,6 @@ python-slugify==6.1.2
 python-socketio==5.7.1
 pytz==2022.1
 pytzdata==2020.1
-pywin32==304
 PyYAML==5.4.1
 pyzbar==0.1.9
 readchar==3.1.0


### PR DESCRIPTION
I've added conditional environment markers for Windows platform because a couple of Windows modules were breaking the module install process on Linux platforms. @antoniocorreia Please test this on Windows.